### PR TITLE
Fix syntax error in example script

### DIFF
--- a/Code
+++ b/Code
@@ -79,5 +79,7 @@ predictions = model.predict(test_news)
 
 for news, prediction in zip(test_news, predictions):
     print(f"Новость: {news}")
-    print(f"Прогноз изменения на фондовом рынке: {'рост' если prediction == 1 иначе 'падение'}")
+    print(
+        f"Прогноз изменения на фондовом рынке: {'рост' if prediction == 1 else 'падение'}"
+    )
     print()


### PR DESCRIPTION
## Summary
- fix f-string bug in `Code` for prediction output

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement scikit-learn)*

------
https://chatgpt.com/codex/tasks/task_e_68404abb8c1083329fef80011b8d9d8a